### PR TITLE
Fix error that causes getting performance summary to not work

### DIFF
--- a/nasal/paperwork.nas
+++ b/nasal/paperwork.nas
@@ -100,7 +100,7 @@ var JobSheet = {
                    (me.fuelusage             == nil ? '' : me.fuelusage)             ~ "||" ~
                    (me.repaircosts           == nil ? '' : me.repaircosts)           ~ "||" ~
                    (me.fuelcosts             == nil ? '' : me.fuelcosts)             ~ "||" ~
-                   (me.paymentrecieved       == nil ? '' : me.paymentrecieved)       ~ "\n" ;
+                   (me.paymentrecieved       == nil ? '' : me.paymentrecieved)       ~ "||\n" ;
         return line;
     },
 


### PR DESCRIPTION
Currently only works when no flights are logged.